### PR TITLE
Added transfer policy rule for image mutation 

### DIFF
--- a/example/Move.toml
+++ b/example/Move.toml
@@ -4,7 +4,7 @@ edition = "2024.beta"
 license = "MIT"        
 authors = [
   "Carl Klöfverskjöld (www.github.com/Reblixt)",
-  "Tanta (www.github.com/tantasui)"
+  "Tanta (www.github.com/tantasui)",
 ]
 
 [dependencies]

--- a/example/Move.toml
+++ b/example/Move.toml
@@ -4,6 +4,7 @@ edition = "2024.beta"
 license = "MIT"        
 authors = [
   "Carl Klöfverskjöld (www.github.com/Reblixt)",
+  "Tanta (www.github.com/tantasui)"
 ]
 
 [dependencies]

--- a/nft/Move.toml
+++ b/nft/Move.toml
@@ -4,6 +4,7 @@ edition = "2024.beta"
 license = "MIT"
 authors = [
   "Carl Klöfverskjöld (www.github.com/Reblixt)",
+  "Tanta (www.github.com/tantasui)",
 ]
 version = "1"
 

--- a/nft/sources/collectible.move
+++ b/nft/sources/collectible.move
@@ -9,9 +9,12 @@ module nft::collectible {
         dynamic_object_field as dyn_field,
         event::emit,
         package::{Self, Publisher},
-        transfer_policy::{Self as policy, TransferPolicyCap},
+        transfer_policy::{Self as policy, TransferPolicyCap, TransferPolicy, TransferRequest},
         vec_map::{Self as map, VecMap}
     };
+    use sui::coin::{Self, Coin};
+    use sui::sui::SUI;
+    use nft::render_fee_rule;
 
     public struct Meta_borrow {
         collectible_id: ID,
@@ -363,17 +366,21 @@ module nft::collectible {
     public fun update_image<T: store>(
         collectible: &mut Collectible<T>,
         collection: &mut Collection<T>,
+        policy: &mut TransferPolicy<T>,
+        request: &mut TransferRequest<T>,
+        payment: Coin<SUI>,
         attribute_id: ID,
         new_image_url: String,
         render_node: RenderNode,
         _: &mut TxContext,
     ) {
         collection.assert_dynamic();
+        
         let RenderNode { attribute_id: attr_id, nft_id, old_nft_image_url } = render_node;
         assert!(attribute_id == attr_id);
         assert!(nft_id == collectible.id.to_inner());
         assert!(old_nft_image_url == collectible.image_url && new_image_url != old_nft_image_url);
-
+        render_fee_rule::pay(policy, request, payment);
         collectible.image_url = new_image_url;
     }
 

--- a/nft/sources/render_fee_rule.move
+++ b/nft/sources/render_fee_rule.move
@@ -1,0 +1,51 @@
+module nft::render_fee_rule;
+use sui::transfer_policy::{
+Self,
+TransferPolicy,
+TransferPolicyCap,
+TransferRequest};
+use sui::coin::{Self, Coin};
+use sui::sui::SUI;
+
+
+
+
+
+const ERR_INSUFFICIENT_PAYMENT: u64 = 4;
+// Rule witness type
+public struct RenderFeeRule has drop {}
+
+// Configuration for the rule
+public struct RenderFeeConfig has store, drop {
+fee_amount: u64 // Authorized domain for the image service
+}
+
+
+
+public fun add_rule<T>(
+policy: &mut TransferPolicy<T>,
+cap: &TransferPolicyCap<T>,
+fee_amount: u64,
+) {
+transfer_policy::add_rule(RenderFeeRule {}, policy, cap, RenderFeeConfig {
+    fee_amount
+});
+}
+
+public fun pay<T>(
+policy: &mut TransferPolicy<T>,
+request: &mut TransferRequest<T>,
+payment: Coin<SUI>,
+) {
+let config: &RenderFeeConfig = transfer_policy::get_rule(RenderFeeRule{},policy);
+    
+
+// Verify payment
+assert!(coin::value(&payment) >= config.fee_amount, ERR_INSUFFICIENT_PAYMENT);
+
+transfer_policy::add_to_balance(RenderFeeRule {}, policy, payment);
+// Verify image URL domain
+
+// Mark request as paid
+transfer_policy::add_receipt( RenderFeeRule {}, request);
+}


### PR DESCRIPTION
I added the transfer policy for image mutation it makes sure that a fee is paid when the image is to be mutated. the rule is set in the render_fee_rule. move file and is called in the update image function in the collectible.move file. i could not implement other functionalities like the personal-signature verification(was too complex for me, we may have to try another approach) please do well to review my code and give me ay feedback(i am expecting) so i can make changes as as soon as possible. thanks :)